### PR TITLE
Async/Await in useEffect - Fixes #3

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,20 +7,22 @@ const App = () => {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch(API_URL)
-    .then((res) => {
-      if (!res.ok) throw new Error('Failed to fetch data');
-      return res.json();
-    })
-    .then((data) => {
-      console.log(data);
-      setCoins(data);
-      setLoading(false);
-    })
-    .catch((err) => {
-      setError(err.message);
-      setLoading(false);
-    })
+    const fetchCoins = async () => {
+      try {
+        const res = await fetch(API_URL)
+        if (!res.ok) throw new Error('Failed to fetch data');
+        const data = await res.json();
+        console.log(data);
+        setCoins(data)
+      } catch (err) {
+        setError(err.message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchCoins();
+
   }, [])
 
   return ( 
@@ -30,3 +32,4 @@ const App = () => {
    );
 }
  
+export default App;


### PR DESCRIPTION
## Points essentiels à retenir

1. **Le `fetch` renvoie une promesse**, donc on doit la gérer avec `await` ou `.then()`.
2. On **ne peut pas rendre `useEffect` directement asynchrone**.
    
    → On crée une fonction `async` *à l’intérieur* du `useEffect`, puis on l’appelle.
    
3. Toujours utiliser un **bloc `try/catch/finally`** :
    - `try`: pour exécuter le `fetch`.
    - `catch`: pour capturer les erreurs.
    - `finally`: pour arrêter le chargement quoi qu’il arrive.
4. Vérifier si `response.ok` est vrai avant de convertir la réponse en JSON.
5. Mettre à jour le **state** avec les données reçues.