### PR TITLE
Limit Selector - Fixes #9

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,18 @@
 import { useState, useEffect } from "react";
 import CoinCard from "./components/CoinCard";
+import LimitSelector from "./components/LimitSelector";
 const API_URL = import.meta.env.VITE_API_URL;
 
 const App = () => {
   const [coins, setCoins] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [limit, setLimit] = useState(10);
 
   useEffect(() => {
     const fetchCoins = async () => {
       try {
-        const res = await fetch(`${API_URL}&order=market_cap_desc&per_page=10&page=1&sparkline=false`)
+        const res = await fetch(`${API_URL}&order=market_cap_desc&per_page=${limit}&page=1&sparkline=false`)
         if (!res.ok) throw new Error('Failed to fetch data');
         const data = await res.json();
         console.log(data);
@@ -24,13 +26,15 @@ const App = () => {
 
     fetchCoins();
 
-  }, [])
+  }, [limit])
 
   return ( 
     <div>
       <h1>🚀 Crypto Dash</h1>
       {loading && <p>Loading...</p>}
       {error && <div className="error">{error}</div>}
+
+     <LimitSelector limit={limit} onLimitChange={setLimit} />
 
       {!loading && !error && (
         <main className="grid">

--- a/src/components/LimitSelector.jsx
+++ b/src/components/LimitSelector.jsx
@@ -1,0 +1,17 @@
+const LimitSelector = ({limit, onLimitChange}) => {
+    return (
+        <div className="controls">
+            <label htmlFor="limit">Show: </label>
+            <select value={limit} id="limit"
+            onChange={(e) => onLimitChange(Number(e.target.value))}>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+            </select>
+      </div>
+     );
+}
+ 
+export default LimitSelector;


### PR DESCRIPTION
**Explications clés :**

- `useEffect` dépend de `[limit]`, donc à chaque changement, les données sont rechargées.
- `setLimit(Number(e.target.value))` permet de convertir la valeur sélectionnée (string) en nombre.
- `per_page=${limit}` est passé dans l’URL de l’API pour modifier le nombre d’éléments renvoyés.